### PR TITLE
For PyPi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *~
 [#]*[#]
+
+# for build
+build/
+dist/ 
+lilcom.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include lilcom *.h

--- a/lilcom/lilcom.c
+++ b/lilcom/lilcom.c
@@ -1,10 +1,10 @@
-#include "lilcom.h"
 #include <assert.h>
 #include <stdlib.h>  /* for malloc */
 #include <math.h>  /* for frexp and frexpf and pow, used in floating point compression. */
 #include <stdio.h>  /* TEMP-- for debugging. */
 #include <float.h>  /* for FLT_MAX */
 
+#include "lilcom.h"
 
 /**
    The version number of the format.   Note: you can't change the various

--- a/lilcom/lilcom_c_extension.c
+++ b/lilcom/lilcom_c_extension.c
@@ -6,7 +6,7 @@
 #include "numpy/arrayobject.h"
 
 /* The core library */
-#include "./lilcom.h"
+#include "lilcom.h"
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extension_mod = Extension("lilcom.lilcom_c_extension",
 setup(
     name = "lilcom",
     python_requires='>=3.5',
-    version = "0.0.3",
+    version = "0.0.0",
     author = "Daniel Povey, Soroush Zargar, Mahsa Yarmohammadi",
     author_email = "dpovey@gmail.com",
     description = ("Small compression utility for sequence data in NumPy"),

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 extension_mod = Extension("lilcom.lilcom_c_extension",
-                          sources=["lilcom/lilcom_c_extension.c","lilcom/lilcom.c"],
+                          sources=["lilcom/lilcom_c_extension.c",
+                                   "lilcom/lilcom.c"],
                           extra_compile_args=["-DNDEBUG"],
                           #extra_compile_args=["-g"],
                           include_dirs=[numpy.get_include()])
@@ -33,16 +34,17 @@ extension_mod = Extension("lilcom.lilcom_c_extension",
 setup(
     name = "lilcom",
     python_requires='>=3.5',
-    version = "0.0.0",
+    version = "0.0.3",
     author = "Daniel Povey, Soroush Zargar, Mahsa Yarmohammadi",
     author_email = "dpovey@gmail.com",
     description = ("Small compression utility for sequence data in NumPy"),
     license = "BSD",
     keywords = "compression numpy",
     packages=['lilcom'],
-    url = "http://packages.python.org/an_example_pypi_project",
+    url = "https://github.com/danpovey/lilcom",
     ext_modules=[extension_mod],
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 1 - Planning",
         "Topic :: Utilities",


### PR DESCRIPTION
Hi, I give some modifications for PyPi release and test it on TestPyPi on my side. Now you can try 
```
pip install --index-url https://test.pypi.org/simple lilcom
```
to install it from https://test.pypi.org/

To release it on PyPi officially, we need to register user account on https://pypi.org. The release progress is simple. Following
```
python setup.py sdsit
twine upload dist/*
```
can publish the lilcom package on PyPi.