### PR TITLE
Windows support

### DIFF
--- a/lilcom/int_math_utils.h
+++ b/lilcom/int_math_utils.h
@@ -6,7 +6,9 @@
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>
-//#include <strings.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 #include <stdlib.h>  /* for abs. */
 
 #ifdef _MSC_VER
@@ -29,16 +31,10 @@ static inline int __builtin_ctzl(unsigned long x) {
 }
 
 static inline int __builtin_clz(unsigned x) {
-    //unsigned long ret;
-    //_BitScanReverse(&ret, x);
-    //return (int)(31 ^ ret);
     return (int)__lzcnt(x);
 }
 
 static inline int __builtin_clzll(unsigned long long x) {
-    //unsigned long ret;
-    //_BitScanReverse64(&ret, x);
-    //return (int)(63 ^ ret);
     return (int)__lzcnt64(x);
 }
 

--- a/lilcom/int_math_utils.h
+++ b/lilcom/int_math_utils.h
@@ -6,9 +6,56 @@
 #include <stdint.h>
 #include <assert.h>
 #include <string.h>
-#include <strings.h>
+//#include <strings.h>
 #include <stdlib.h>  /* for abs. */
 
+#ifdef _MSC_VER
+#include <intrin.h>
+
+static inline int __builtin_ctz(unsigned x) {
+    unsigned long ret;
+    _BitScanForward(&ret, x);
+    return (int)ret;
+}
+
+static inline int __builtin_ctzll(unsigned long long x) {
+    unsigned long ret;
+    _BitScanForward64(&ret, x);
+    return (int)ret;
+}
+
+static inline int __builtin_ctzl(unsigned long x) {
+    return sizeof(x) == 8 ? __builtin_ctzll(x) : __builtin_ctz((uint32_t)x);
+}
+
+static inline int __builtin_clz(unsigned x) {
+    //unsigned long ret;
+    //_BitScanReverse(&ret, x);
+    //return (int)(31 ^ ret);
+    return (int)__lzcnt(x);
+}
+
+static inline int __builtin_clzll(unsigned long long x) {
+    //unsigned long ret;
+    //_BitScanReverse64(&ret, x);
+    //return (int)(63 ^ ret);
+    return (int)__lzcnt64(x);
+}
+
+static inline int __builtin_clzl(unsigned long x) {
+    return sizeof(x) == 8 ? __builtin_clzll(x) : __builtin_clz((uint32_t)x);
+}
+
+#ifdef __cplusplus
+static inline int __builtin_ctzl(unsigned long long x) {
+    return __builtin_ctzll(x);
+}
+
+static inline int __builtin_clzl(unsigned long long x) {
+    return __builtin_clzll(x);
+}
+#endif
+#endif
 
 
 namespace int_math {

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extension_mod = Extension("lilcom.lilcom_extension",
                           # catch errors.  -ftrapv detects overflow in
                           # signed integer arithmetic (which technically
                           # leads to undefined behavior).
-                          extra_compile_args=["-g", "-Wall", "-UNDEBUG", "-Wno-c++11-compat-deprecated-writable-strings"], #, "-ftrapv"],
+                          #extra_compile_args=["-g", "-Wall", "-UNDEBUG"], #, "-Wno-c++11-compat-deprecated-writable-strings"], #, "-ftrapv"],
                           include_dirs=[get_numpy_include()])
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 # Check python version: If python 3 was not found then it returns 1 and does
 #   not do anything
-from platform import python_version
+from platform import python_version, system
 primer_version = python_version().split(".")
 if int(primer_version[0]) != 3:
     print ("This module only works with python3")
@@ -43,7 +43,7 @@ extension_mod = Extension("lilcom.lilcom_extension",
                           # catch errors.  -ftrapv detects overflow in
                           # signed integer arithmetic (which technically
                           # leads to undefined behavior).
-                          #extra_compile_args=["-g", "-Wall", "-UNDEBUG"], #, "-Wno-c++11-compat-deprecated-writable-strings"], #, "-ftrapv"],
+                          extra_compile_args=["-g", "-Wall", "-UNDEBUG", "-Wno-c++11-compat-deprecated-writable-strings"] if system != "Windows" else [], #, "-ftrapv"],
                           include_dirs=[get_numpy_include()])
 
 setup(


### PR DESCRIPTION
I'm working on making lilcom compile on Windows (mainly because it's a dependency of lhotse). I added some MSVC-specific implementations for `__builtin_ctz` etc.

When running the tests, I get the following results:
```
lilcom\test>python test_lilcom.py
len(b) =  4388 , bytes per number =  2.194
max,min diff = 1.5258173853505141e-05, -1.5258730931277942e-05, expected magnitude was 6.52587890625e-05
len(b) =  2633 , bytes per number =  1.3165
max,min diff = 0.001949594090473905, -0.0019530548706436779, expected magnitude was 0.002003125
len(b) =  2133 , bytes per number =  1.0665
max,min diff = 0.007808582235617978, -0.007811021846953814, expected magnitude was 0.0078625
len(b) =  145 , bytes per number =  2.4166666666666665
max,min diff = 1.4499648896798556e-05, -1.5219483600947825e-05, expected magnitude was 6.52587890625e-05
len(b) =  87 , bytes per number =  1.45
max,min diff = 0.001863664044361557, -0.001874540539916314, expected magnitude was 0.002003125
len(b) =  72 , bytes per number =  1.2
max,min diff = 0.007643991073694512, -0.0074209681746184725, expected magnitude was 0.0078625
len(b) =  96 , bytes per number =  2.742857142857143
max,min diff = 1.5217219663687942e-05, -1.4267023458192085e-05, expected magnitude was 6.52587890625e-05
len(b) =  58 , bytes per number =  1.6571428571428573
max,min diff = 0.0017838232389706388, -0.001875839289083192, expected magnitude was 0.002003125
len(b) =  49 , bytes per number =  1.4
max,min diff = 0.007504112599278745, -0.00705976611706749, expected magnitude was 0.0078625
len(b) =  190 , bytes per number =  2.375
max,min diff = 1.4664579023548896e-05, -1.505935138945702e-05, expected magnitude was 6.52587890625e-05
len(b) =  114 , bytes per number =  1.425
max,min diff = 0.001906196098753199, -0.0017493009557283945, expected magnitude was 0.002003125
len(b) =  94 , bytes per number =  1.175
max,min diff = 0.007797800742352701, -0.007377709634650453, expected magnitude was 0.0078625
len(b) =  24991 , bytes per number =  2.1921929824561404
max,min diff = 1.5342245469618376e-05, -1.5313208520773003e-05, expected magnitude was 6.52587890625e-05
len(b) =  15013 , bytes per number =  1.3169298245614036
max,min diff = 0.001952997587624794, -0.001953012583189473, expected magnitude was 0.002003125
len(b) =  12163 , bytes per number =  1.0669298245614036
max,min diff = 0.00781205967070564, -0.007812139258255843, expected magnitude was 0.0078625
```
From what I can tell, all differences are below the limit in the assert.