### PR TITLE
Fixed bug that crashed install on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extension_mod = Extension("lilcom.lilcom_extension",
                           # catch errors.  -ftrapv detects overflow in
                           # signed integer arithmetic (which technically
                           # leads to undefined behavior).
-                          extra_compile_args=["-g", "-Wall", "-UNDEBUG", "-Wno-c++11-compat-deprecated-writable-strings"] if system != "Windows" else [], #, "-ftrapv"],
+                          extra_compile_args=["-g", "-Wall", "-UNDEBUG", "-Wno-c++11-compat-deprecated-writable-strings"] if system() != "Windows" else [], #, "-ftrapv"],
                           include_dirs=[get_numpy_include()])
 
 setup(


### PR DESCRIPTION
Hi! 

In line 46 of setup.py, `system` was called as a variable whereas it is a function imported from `platform`. This fixes the problem and enables using lilcom on Windows. I got here by debugging why Lhotse cannot be built on this system.

Kind regards,
Marcin Witkowski