### PR TITLE
Fix https://github.com/lhotse-speech/lhotse/issues/800

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ pybind11_add_module(lilcom_extension
 
 if(UNIX AND NOT APPLE)
   target_link_libraries(lilcom_extension PRIVATE ${PYTHON_LIBRARY})
+
+  # Fix https://github.com/lhotse-speech/lhotse/issues/800
+  target_link_libraries(lilcom_extension PUBLIC "-Wl,-rpath,${LILCOM_RPATH_ORIGIN}/../..")
 elseif(WIN32)
   target_link_libraries(lilcom_extension PRIVATE ${PYTHON_LIBRARIES})
 endif()


### PR DESCRIPTION
Embed the `rpath` into the `.so` so that users don't need to specify `LD_LIBRARY_PATH`.

Fix https://github.com/lhotse-speech/lhotse/issues/800#issuecomment-1323025702