### PR TITLE
release numpy version restriction for python3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,8 @@ install_requires = [
     "Cython; sys_platform=='win32' and python_version >= '3.10'",
     "numpy<=1.19.5; python_version >= '3.6' and python_version < '3.7'",
     "numpy<=1.21.6; python_version >= '3.7' and python_version < '3.8'",
-    "numpy<1.23.0; python_version >= '3.8' and python_version <= '3.10'",
-    "numpy; python_version > '3.10'",
+    "numpy<1.23.0; python_version >= '3.8' and python_version < '3.10'",
+    "numpy; python_version >= '3.10'",
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Continuing https://github.com/danpovey/lilcom/issues/51 I try to remove `numpy` version restriction for python 3.10.