### PR TITLE
Fix CI for publishing PyPI packages

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: "3.10"
 
       - name: Install Python dependencies
         shell: bash


### PR DESCRIPTION
Python 3.6 is no longer supported in GitHub actions. This PR replaces Python 3.6 with 3.10.