### PR TITLE
CI: Add Python 3.14 and update cibuildwheels to latest (v3.3.1)

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         manylinux: [manylinux2014]
 
     steps:
@@ -29,7 +29,7 @@ jobs:
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake==3.31.6 numpy"
           CIBW_BUILD: "${{ matrix.python-version}}-* "

--- a/.github/workflows/build-wheels-macos.yaml
+++ b/.github/workflows/build-wheels-macos.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
+        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake==3.31.6 numpy setuptools wheel"
           CIBW_BUILD: "${{ matrix.python-version}}-* "

--- a/.github/workflows/build-wheels-win64.yaml
+++ b/.github/workflows/build-wheels-win64.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
+        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         manylinux: [manylinux2014] #, manylinux_2_28]
 
     steps:
@@ -29,7 +29,7 @@ jobs:
       # see https://cibuildwheel.readthedocs.io/en/stable/changelog/
       # for a list of versions
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_BEFORE_BUILD: "pip install -U cmake numpy"
           CIBW_BUILD: "${{ matrix.python-version}}-* "


### PR DESCRIPTION
Hi @csukuangfj, I added Python 3.14 and updated cibuildwheels to latest (v3.3.1) in the GH action build-wheel workflows. I unfortunately wasn't able to test the changes in GH actions on my end (only locally; no build issues w/ Python 3.14), but I think they should work (they're similar to recent changes in [kaldialign](https://github.com/pzelasko/kaldialign/commit/efdbf9827352cf7ce06264c4fd18f629fe60545a#diff-410af76704f3f13612fa9c02e2f91a96d39a9aa226ff1c5cdd99316a370101d2)).

EDIT: test_windows seems to fail because there are no wheels on PyPI for the latest numpy for older Python versions and it fails to build. Possible solution is to fix the numpy version used in each checks depending on the Python version to a numpy version with wheels for that Python version. Unfortunately there isn't a numpy version that has wheels for all Python versions between 3.9 and 3.14.