### PR TITLE
Fix building wheels

### DIFF
--- a/.github/workflows/build-wheels-aarch64.yaml
+++ b/.github/workflows/build-wheels-aarch64.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04-arm]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         manylinux: [manylinux2014]
 
     steps:

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        python-version: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        os: [ubuntu-latest]
+        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         manylinux: [manylinux2014] #, manylinux_2_28]
 
     steps:


### PR DESCRIPTION
There was an issue with building wheels for Linux x64 because `ubuntu-20.04` is no longer available.

CC @svandiekendialpad
